### PR TITLE
Fix: Import Link from next/link in layout file

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";


### PR DESCRIPTION
This pull request addresses an issue where the `Link` component was not imported from `next/link` in the `app/layout.tsx` file. This omission caused errors in production. The import statement for `Link` has been added to resolve this issue, ensuring that the layout functions correctly without any errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [lewisham_ass_2/h960mvqh8ozg](https://cosine.sh/yrjq5nfm0654/lewisham_ass_2/task/h960mvqh8ozg)
Author: Abdulhamid Sonaike
